### PR TITLE
Expose batchSize parameter on various indexers 

### DIFF
--- a/indexers/directory-indexer.ts
+++ b/indexers/directory-indexer.ts
@@ -5,6 +5,7 @@ import { FileDocument } from "../document.js";
 export type DirectoryIndexerOpts = {
   rootDir: string;
   urlBase?: string;
+  batchSize?: number;
   getUrl?: (docPathList: string[], sitePathList: string[]) => string;
   getId?: (docPathList: string[], sitePathList: string[]) => string;
   getImageUrl?: (docPathList: string[], sitePathList: string[]) => string;
@@ -13,9 +14,9 @@ export type DirectoryIndexerOpts = {
 };
 
 export class DirectoryIndexer {
-  private parallelism = 25;
-  private rootDir: string;
-  private urlBase?: string;
+  private readonly batchSize: number;
+  private readonly rootDir: string;
+  private readonly urlBase?: string;
   private files: FileDocument[] = [];
   constructor(
     public catalog: Catalog,
@@ -23,6 +24,7 @@ export class DirectoryIndexer {
   ) {
     this.rootDir = opts.rootDir;
     this.urlBase = opts.urlBase;
+    this.batchSize = opts.batchSize ?? 25; 
 
     if (opts.includeFile) {
       this.includeFile = opts.includeFile;
@@ -86,7 +88,7 @@ export class DirectoryIndexer {
       url,
     });
 
-    if (this.files.length >= this.parallelism) {
+    if (this.files.length >= this.batchSize) {
       await this.catalog.upsertDocuments(this.files);
       this.files = [];
     }

--- a/indexers/directory-indexer.ts
+++ b/indexers/directory-indexer.ts
@@ -24,7 +24,7 @@ export class DirectoryIndexer {
   ) {
     this.rootDir = opts.rootDir;
     this.urlBase = opts.urlBase;
-    this.batchSize = opts.batchSize ?? 25; 
+    this.batchSize = opts.batchSize ?? 25;
 
     if (opts.includeFile) {
       this.includeFile = opts.includeFile;

--- a/indexers/json-indexer.ts
+++ b/indexers/json-indexer.ts
@@ -5,7 +5,7 @@ import { JSONDocument } from "../document.js";
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 
 export type JSONIndexerOpts = {
-  batchSize?: number | undefined;
+  batchSize?: number;
   getId?: (document: any) => string;
   getUrl?: (document: any) => string | undefined;
   getImageUrl?: (document: any) => string | undefined;

--- a/indexers/json-indexer.ts
+++ b/indexers/json-indexer.ts
@@ -5,13 +5,14 @@ import { JSONDocument } from "../document.js";
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 
 export type JSONIndexerOpts = {
+  batchSize?: number | undefined;
   getId?: (document: any) => string;
   getUrl?: (document: any) => string | undefined;
   getImageUrl?: (document: any) => string | undefined;
 };
 
 export class JSONIndexer {
-  private readonly parallelism = 50;
+  private readonly batchSize: number;
   private readonly getId: (document: any) => string;
   private readonly getImageUrl: (document: any) => string | undefined;
   private readonly getUrl: (document: any) => string | undefined;
@@ -22,6 +23,7 @@ export class JSONIndexer {
     private documents: any[],
     opts?: JSONIndexerOpts,
   ) {
+    this.batchSize = opts?.batchSize ?? 50;
     this.getId = opts?.getId ?? JSONIndexer.defaultGetId;
     this.getUrl = opts?.getUrl ?? JSONIndexer.defaultGetUrl;
     this.getImageUrl = opts?.getImageUrl ?? JSONIndexer.defaultGetImageUrl;
@@ -74,7 +76,7 @@ export class JSONIndexer {
 
   private async indexItems(): Promise<void> {
     for (const document of this.documents) {
-      if (this.batch.length > this.parallelism) {
+      if (this.batch.length > this.batchSize) {
         await this.catalog.upsertDocuments(this.batch);
         this.batch = [];
       }

--- a/indexers/shopify-indexer.ts
+++ b/indexers/shopify-indexer.ts
@@ -99,7 +99,9 @@ export class ShopifyIndexer {
   }
 
   private async indexProducts(): Promise<void> {
-    const indexer = this.catalog.jsonIndexer(this.documents, { batchSize: this.batchSize });
+    const indexer = this.catalog.jsonIndexer(this.documents, {
+      batchSize: this.batchSize,
+    });
     await indexer.index();
   }
 

--- a/indexers/tsv-indexer.ts
+++ b/indexers/tsv-indexer.ts
@@ -6,6 +6,7 @@ import { JSONIndexer } from "./json-indexer.js";
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 
 export type TSVIndexerOpts = {
+  batchSize?: number;
   getId?: (item: any) => string;
   getUrl?: (item: any) => string;
   getImageUrl?: (item: any) => string;
@@ -16,9 +17,10 @@ export class TSVIndexer {
   private readonly getId: (document: any) => string;
   private readonly getImageUrl: (document: any) => string | undefined;
   private readonly getUrl: (document: any) => string | undefined;
+  private readonly fieldMapping: undefined | { [key: string]: string };
+  private readonly batchSize?: number;
   private documents: any[] = [];
-  private fieldMapping: undefined | { [key: string]: string };
-
+  
   constructor(
     public catalog: Catalog,
     private file: string,
@@ -27,6 +29,7 @@ export class TSVIndexer {
     this.getId = opts?.getId ?? JSONIndexer.defaultGetId;
     this.getUrl = opts?.getUrl ?? JSONIndexer.defaultGetUrl;
     this.getImageUrl = opts?.getImageUrl ?? JSONIndexer.defaultGetImageUrl;
+    this.batchSize = opts?.batchSize;
 
     if (opts?.fieldMapping) {
       this.fieldMapping = opts?.fieldMapping;
@@ -64,7 +67,7 @@ export class TSVIndexer {
       });
     }
 
-    const jsonIndexer = this.catalog.jsonIndexer(this.documents);
+    const jsonIndexer = this.catalog.jsonIndexer(this.documents, { batchSize: this.batchSize });
 
     await jsonIndexer.index();
   }

--- a/indexers/tsv-indexer.ts
+++ b/indexers/tsv-indexer.ts
@@ -20,7 +20,7 @@ export class TSVIndexer {
   private readonly fieldMapping: undefined | { [key: string]: string };
   private readonly batchSize?: number;
   private documents: any[] = [];
-  
+
   constructor(
     public catalog: Catalog,
     private file: string,
@@ -67,7 +67,9 @@ export class TSVIndexer {
       });
     }
 
-    const jsonIndexer = this.catalog.jsonIndexer(this.documents, { batchSize: this.batchSize });
+    const jsonIndexer = this.catalog.jsonIndexer(this.documents, {
+      batchSize: this.batchSize,
+    });
 
     await jsonIndexer.index();
   }


### PR DESCRIPTION
Expose `batchSize` parameter on various indexers. Fixes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `batchSize` configuration for directory, Shopify, and TSV indexers to enhance control over file processing and indexing operations. This allows for more efficient handling of large datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->