### PR TITLE
Check request size for POST and POSTForm requests 

### DIFF
--- a/api-client.ts
+++ b/api-client.ts
@@ -64,7 +64,7 @@ export class CortexApiClient {
 
   private static getFormDataSize(formData: FormData) {
     return [...formData].reduce(
-      (size, [name, value]) =>
+      (size, [_, value]) =>
         size + (typeof value === "string" ? value.length : value.size),
       0,
     );

--- a/api-client.ts
+++ b/api-client.ts
@@ -41,14 +41,13 @@ export class CortexApiClient {
       },
       body: form,
     });
-    form.values.length;
   }
 
   private async makeRequest(method: Method, path: string, body?: any) {
     const requestBody = body ? JSON.stringify(body) : undefined;
     // Note that we use character size instead of byte size. This is still a useful heuristic as we don't want to incur the overhead
     // of using TextEncoder to calculate the precise byte count
-    if (requestBody && requestBody.length >= this.maxRequestSize) {
+    if (requestBody && requestBody.length > this.maxRequestSize) {
       throw new Error("Request body too large");
     }
 
@@ -65,6 +64,7 @@ export class CortexApiClient {
   private static getFormDataSize(formData: FormData) {
     return [...formData].reduce(
       (size, [_, value]) =>
+        // Use heuristic of string length instead of byte size, to avoid incurring the cost of using TextEncoder
         size + (typeof value === "string" ? value.length : value.size),
       0,
     );

--- a/content.test.ts
+++ b/content.test.ts
@@ -82,6 +82,12 @@ test(
     expect(content.version).toBe(0);
     expect(content.commands.length).toBe(1);
 
+    // check that prompt that is too large will fail gracefully without hitting the service
+    const hugePrompt = "p".repeat(32 * 1000 * 1000);
+    await expect(() =>
+      cortex.generateContent({ title, prompt: hugePrompt }),
+    ).rejects.toThrow("Request body too large");
+
     // get content
     const getContent = await testClient.getContent(content.id);
     expect(getContent.content.length).toBe(content.content.length);


### PR DESCRIPTION
Check request size for POST and POSTForm requests. Fixes #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a request size limit to enhance stability and prevent oversized requests.
  - Added error handling for requests that exceed the size limit.

- **Tests**
  - Added a new test case to ensure proper error handling for oversized request bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->