### PR TITLE
Add support for externalUserId for chats.

### DIFF
--- a/chat.test.ts
+++ b/chat.test.ts
@@ -52,13 +52,14 @@ test("e2e catalog, cortex, and sync chat", { timeout: 60000 }, async () => {
 
   // create chat
   const chatInput = "what customers does cortex click have?";
-  const chat = await cortex.chat({ message: chatInput });
+  const chat = await cortex.chat({ message: chatInput, externalUserId: "123" });
   expect(chat.messages[1].message.length).toBeGreaterThan(0);
 
   // get chat
   const getChatRes = await testClient.getChat(chat.id);
   expect(getChatRes.messages.length).toBe(2);
   expect(getChatRes.title).toBe(chatInput);
+  expect(getChatRes.externalUserId).toBe("123");
 
   // respond to chat
   await chat.respond({ message: "what about customer verticals" });
@@ -131,6 +132,7 @@ test("streaming chat", { timeout: 60000 }, async () => {
     message: chatInput,
     stream: true,
     statusStream,
+    externalUserId: "123",
   });
 
   let fullMessage = "";
@@ -158,6 +160,7 @@ test("streaming chat", { timeout: 60000 }, async () => {
     chatResult.messages[chatResult.messages.length - 1].message,
   );
   expect(chatResult.messages.length).toBe(2);
+  expect(chatResult.externalUserId).toBe("123");
   expect(sawChat).toBe(true);
 
   // respond to chat

--- a/chat.ts
+++ b/chat.ts
@@ -58,7 +58,7 @@ export interface ChatListOpts {
   cursor?: string;
   pageSize?: number;
   userEmail?: string | null;
-  externalUserId?: string | null;
+  externalUserId?: string;
   cortexName?: string;
 }
 

--- a/client.ts
+++ b/client.ts
@@ -54,6 +54,7 @@ export interface ClientListChatOpts {
   pageSize?: number;
   cursor?: string;
   userEmail?: string | null;
+  externalUserId?: string | null;
   cortexName?: string;
 }
 

--- a/client.ts
+++ b/client.ts
@@ -54,7 +54,7 @@ export interface ClientListChatOpts {
   pageSize?: number;
   cursor?: string;
   userEmail?: string | null;
-  externalUserId?: string | null;
+  externalUserId?: string;
   cortexName?: string;
 }
 

--- a/cortex.ts
+++ b/cortex.ts
@@ -90,6 +90,7 @@ export interface CortexCreateChatOptsBase {
   message: string;
   stream?: boolean;
   statusStream?: Readable;
+  externalUserId?: string;
 }
 
 export interface CortexCreateChatOptsStreaming
@@ -192,6 +193,7 @@ export class Cortex {
         message: opts.message,
         statusStream: opts.statusStream,
         stream: true,
+        externalUserId: opts.externalUserId,
       });
     } else {
       return Chat.create({
@@ -200,6 +202,7 @@ export class Cortex {
         message: opts.message,
         statusStream: opts.statusStream,
         stream: false,
+        externalUserId: opts.externalUserId,
       });
     }
   }

--- a/indexers/shopify-indexer.ts
+++ b/indexers/shopify-indexer.ts
@@ -81,7 +81,7 @@ export class ShopifyIndexer {
         }
 
         this.documents.push({
-          id: item.id,
+          id: item.id.toString(),
           title: item.title,
           description: this.stripHTML(item.body_html),
           productType: item.product_type,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for `externalUserId` in various chat functionalities including chat creation, listing, and responses.
- **Bug Fixes**
	- Ensured consistent `id` property format by converting `item.id` to a string in Shopify indexer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->