### PR TITLE
Validate that batch passed to Catalog.upsertDocuments is not empty

### DIFF
--- a/catalog.ts
+++ b/catalog.ts
@@ -128,6 +128,10 @@ export class Catalog {
   }
 
   public async upsertDocuments(batch: DocumentBatch) {
+    if (batch.length === 0) {
+      throw new Error("Document batch must not be empty");
+    }
+
     this.checkDeleted();
     let hasText = false;
     let hasFile = false;


### PR DESCRIPTION
Validate that batch passed to Catalog.upsertDocuments is not empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the stability of document upsert operations by adding a validation check to ensure the batch parameter is not empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->