### PR TITLE
Fix #28

### DIFF
--- a/cortex.test.ts
+++ b/cortex.test.ts
@@ -48,7 +48,6 @@ test("can configure, get, and delete and Cortexes", async () => {
     overrides: {
       companyInfo: "a very good company that does AI stuff",
       companyName: "Cortex Click, Inc. --test",
-      inheritRules: false,
     },
   };
 
@@ -56,11 +55,12 @@ test("can configure, get, and delete and Cortexes", async () => {
 
   cortex = await testClient.getCortex(cortexName);
   expect(cortex.config.catalogs).toStrictEqual(cortexConfig.catalogs);
+  expect(cortex.config.overrides?.inheritRules).toBe(true); // test input doesn't specify `inheritRules`, should be true by default 
   // TODO - check all the properties
 
   // delete the cortex
   await cortex.delete();
-  // assert that the get failes
+  // assert that the get fails
   await expect(async () => {
     await testClient.getCortex(cortexName);
   }).rejects.toThrowError("Failed to get cortex: Not Found");

--- a/cortex.test.ts
+++ b/cortex.test.ts
@@ -55,7 +55,7 @@ test("can configure, get, and delete and Cortexes", async () => {
 
   cortex = await testClient.getCortex(cortexName);
   expect(cortex.config.catalogs).toStrictEqual(cortexConfig.catalogs);
-  expect(cortex.config.overrides?.inheritRules).toBe(true); // test input doesn't specify `inheritRules`, should be true by default 
+  expect(cortex.config.overrides?.inheritRules).toBe(true); // test input doesn't specify `inheritRules`, should be true by default
   // TODO - check all the properties
 
   // delete the cortex

--- a/cortex.ts
+++ b/cortex.ts
@@ -134,7 +134,7 @@ export class Cortex {
       overrides: {
         companyInfo: body.companyInfo,
         companyName: body.companyName,
-        inheritRules: !!body.inheritRules,
+        inheritRules: body.inheritRules === false ? false : true,
       },
     };
     return new Cortex(config, apiClient, name);
@@ -156,7 +156,7 @@ export class Cortex {
       examples: config.chatConfig?.examples,
       greeting: config.chatConfig?.greeting,
       intro: config.chatConfig?.intro,
-      inheritRules: !!config.overrides?.inheritRules,
+      inheritRules: config.overrides?.inheritRules === false ? false : true,
       public: !!config.public,
       instructions: config.instructions,
       personality: config.customizations?.personality,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "cortex-sdk",
-  "version": "0.0.1",
+  "name": "@cortexclick/cortex",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cortex-sdk",
-      "version": "0.0.1",
-      "license": "ISC",
+      "name": "@cortexclick/cortex",
+      "version": "0.0.3",
+      "license": "Apache-2.0",
       "dependencies": {
         "form-data": "^4.0.0"
       },


### PR DESCRIPTION
Explicitly check for `false` instead coercing the boolean value and use `true` as the default 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the logic for setting the `inheritRules` property to ensure it accurately reflects the provided configuration.

- **Tests**
  - Updated tests to reflect the new default behavior of the `inheritRules` property.
  - Fixed a typo in test comments from "failes" to "fails."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->