### PR TITLE
Load metadata from stream instead of headers.

### DIFF
--- a/chat.ts
+++ b/chat.ts
@@ -150,7 +150,7 @@ export class Chat {
       decoder,
       readableStream,
       opts.statusStream,
-    ).then((content) => {
+    ).then(([content]) => {
       const messages: Message[] = [
         {
           role: "user",
@@ -296,7 +296,7 @@ export class Chat {
       decoder,
       readableStream,
       opts.statusStream,
-    ).then((content) => {
+    ).then(([content]) => {
       this.messages.push(
         {
           role: "user",

--- a/content.ts
+++ b/content.ts
@@ -194,6 +194,7 @@ export class Content {
       title,
       prompt,
       stream,
+      base64encodeContentHeaders: true,
     });
     const reader = res.body!.getReader();
     const decoder = new TextDecoder("utf-8");
@@ -207,7 +208,8 @@ export class Content {
       res.headers.get("publishedVersion"),
     );
     const commands: ContentCommand[] = JSON.parse(
-      res.headers.get("commands") || "[]",
+      Buffer.from(res.headers.get("commands") || "", "base64").toString() ||
+        "[]",
     );
 
     const readableStream = new Readable({
@@ -317,6 +319,7 @@ export class Content {
     const res = await this.apiClient.POST(`/content/${this._id}/refine`, {
       prompt,
       stream: true,
+      base64encodeContentHeaders: true,
     });
     const reader = res.body!.getReader();
     const decoder = new TextDecoder("utf-8");
@@ -325,8 +328,13 @@ export class Content {
     const createdAt = res.headers.get("createdAt") || "";
     const userEmail = res.headers.get("userEmail") || undefined;
     const commands: ContentCommand[] = JSON.parse(
-      res.headers.get("commands") || "[]",
+      Buffer.from(res.headers.get("commands") || "", "base64").toString() ||
+        "[]",
     );
+    const title = Buffer.from(
+      res.headers.get("title") || "",
+      "base64",
+    ).toString();
     const status = res.headers.get("status") as ContentStatus;
     const publishedVersion: number | undefined = numberOrUndefined(
       res.headers.get("publishedVersion"),
@@ -337,6 +345,7 @@ export class Content {
     this._userEmail = userEmail;
     this._status = status;
     this._publishedVersion = publishedVersion;
+    this._title = title;
 
     const readableStream = new Readable({
       read() {},

--- a/content.ts
+++ b/content.ts
@@ -89,6 +89,18 @@ export type ContentListOptions = {
   cortexName?: string;
 };
 
+export type ContentMetadata = {
+  id: string;
+  title: string;
+  version: number;
+  commands: ContentCommand[];
+  cortex: string;
+  createdAt: string;
+  userEmail: string;
+  status: ContentStatus;
+  publishedVersion: number | null;
+};
+
 export class Content {
   get id() {
     return this._id;
@@ -194,46 +206,37 @@ export class Content {
       title,
       prompt,
       stream,
-      base64encodeContentHeaders: true,
+      noContentInHeaders: true,
     });
     const reader = res.body!.getReader();
     const decoder = new TextDecoder("utf-8");
-
-    const id: string = res.headers.get("id") || "";
-    const version: number = parseInt(res.headers.get("version") || "0");
-    const userEmail = res.headers.get("userEmail") || undefined;
-    const createdAt: string = res.headers.get("createdAt") || "";
-    const status: ContentStatus = res.headers.get("status") as ContentStatus;
-    const publishedVersion: number | undefined = numberOrUndefined(
-      res.headers.get("publishedVersion"),
-    );
-    const commands: ContentCommand[] = JSON.parse(
-      Buffer.from(res.headers.get("commands") || "", "base64").toString() ||
-        "[]",
-    );
 
     const readableStream = new Readable({
       read() {},
     });
 
-    const contentPromise = processStream(
+    const contentPromise = processStream<ContentMetadata>(
       reader,
       decoder,
       readableStream,
       opts.statusStream,
-    ).then((content) => {
+    ).then(([content, metadata]) => {
+      if (!metadata) {
+        throw new Error("Metadata not found in stream");
+      }
+
       return new Content(
         client,
-        id,
-        title,
+        metadata.id,
+        metadata.title,
         content,
-        commands,
-        version,
-        createdAt,
-        status,
-        cortex.name,
-        userEmail,
-        publishedVersion,
+        metadata.commands,
+        metadata.version,
+        metadata.createdAt,
+        metadata.status,
+        metadata.cortex,
+        metadata.userEmail,
+        metadata.publishedVersion || undefined,
       );
     });
 
@@ -319,45 +322,33 @@ export class Content {
     const res = await this.apiClient.POST(`/content/${this._id}/refine`, {
       prompt,
       stream: true,
-      base64encodeContentHeaders: true,
+      noContentInHeaders: true,
     });
     const reader = res.body!.getReader();
     const decoder = new TextDecoder("utf-8");
-
-    const version: number = parseInt(res.headers.get("version") || "0");
-    const createdAt = res.headers.get("createdAt") || "";
-    const userEmail = res.headers.get("userEmail") || undefined;
-    const commands: ContentCommand[] = JSON.parse(
-      Buffer.from(res.headers.get("commands") || "", "base64").toString() ||
-        "[]",
-    );
-    const title = Buffer.from(
-      res.headers.get("title") || "",
-      "base64",
-    ).toString();
-    const status = res.headers.get("status") as ContentStatus;
-    const publishedVersion: number | undefined = numberOrUndefined(
-      res.headers.get("publishedVersion"),
-    );
-    this._version = version;
-    this._commands = commands;
-    this._createdAt = createdAt;
-    this._userEmail = userEmail;
-    this._status = status;
-    this._publishedVersion = publishedVersion;
-    this._title = title;
 
     const readableStream = new Readable({
       read() {},
     });
 
-    const contentPromise = processStream(
+    const contentPromise = processStream<ContentMetadata>(
       reader,
       decoder,
       readableStream,
       opts.statusStream,
-    ).then((content) => {
+    ).then(([content, metadata]) => {
+      if (!metadata) {
+        throw new Error("Metadata not found in stream");
+      }
+
       this._content = content;
+      this._version = metadata.version;
+      this._commands = metadata.commands;
+      this._createdAt = metadata.createdAt;
+      this._userEmail = metadata.userEmail;
+      this._status = metadata.status;
+      this._publishedVersion = metadata.publishedVersion || undefined;
+      this._title = metadata.title;
       return this;
     });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/cortexclick/cortex-sdk",
     "type": "git"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "main": "index.js",
   "scripts": {

--- a/utils/streaming.ts
+++ b/utils/streaming.ts
@@ -46,7 +46,7 @@ export async function processStream<Metadata extends Record<string, unknown>>(
           else if (json.messageType === "status" && statusStream) {
             statusStream.push(line + "\n");
           } else if (json.messageType === "metadata") {
-            metadata = json.metadata;
+            metadata = json.data;
           }
         } catch (e) {
           console.error("Error parsing JSON:", e);

--- a/utils/streaming.ts
+++ b/utils/streaming.ts
@@ -1,14 +1,16 @@
 import { Readable } from "stream";
 
-export async function processStream(
+export async function processStream<Metadata extends Record<string, unknown>>(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   decoder: TextDecoder,
   contentStream: Readable,
   statusStream?: Readable,
-): Promise<string> {
+): Promise<[string, Metadata | undefined]> {
   let buffer = "";
   let fullContent = "";
   let isStatusStreamOpen = true;
+
+  let metadata: Metadata | undefined = undefined;
 
   const processNextChunk = async (): Promise<void> => {
     const { done, value } = await reader.read();
@@ -43,6 +45,8 @@ export async function processStream(
           // t:s = status message
           else if (json.messageType === "status" && statusStream) {
             statusStream.push(line + "\n");
+          } else if (json.messageType === "metadata") {
+            metadata = json.metadata;
           }
         } catch (e) {
           console.error("Error parsing JSON:", e);
@@ -57,5 +61,5 @@ export async function processStream(
     contentStream.emit("error", error);
   });
 
-  return fullContent;
+  return [fullContent, metadata];
 }


### PR DESCRIPTION
* Pass parameter to indicate to the API to return a metadata message in the stream instead of putting user content in the headers.
* Parse this metadata when processing the stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved handling of HTTP response headers by introducing base64 encoding/decoding for content headers.
  - Added support for decoding `commands` and `title` headers from base64 format.
  - Enhanced content processing by including comprehensive metadata attributes, providing additional context with processed content.

- **Chores**
  - Updated package version to `0.0.5`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->