### PR TITLE
Expose warnings in upsertDocuments API result

### DIFF
--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -51,7 +51,7 @@ export class Catalog {
 
   static async get(apiClient: CortexApiClient, name: string): Promise<Catalog> {
     const res = await apiClient.GET(`/catalogs/${name}`);
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to get catalog: ${res.statusText}`);
     }
     const body = await res.json();
@@ -79,7 +79,7 @@ export class Catalog {
       res = await apiClient.PUT(`/catalogs/${name}`, config);
     }
 
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to configure catalog: ${res.statusText}`);
     }
     return new Catalog(config, apiClient, name);
@@ -121,7 +121,7 @@ export class Catalog {
   public async truncate() {
     this.checkDeleted();
     const res = await this.apiClient.POST(`/catalogs/${this.name}/truncate`);
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to get catalog: ${res.statusText}`);
     }
   }

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -139,7 +139,7 @@ export class Catalog {
     let hasJson = false;
     let hasUrl = false;
     let hasSitemapUrl = false;
-    for (const doc of batch) {
+    for (const [index, doc] of batch.entries()) {
       const contentType = doc.contentType;
       switch (contentType) {
         case "markdown":
@@ -159,7 +159,9 @@ export class Catalog {
           hasSitemapUrl = true;
           break;
         default:
-          throw new Error(`unsupported content type: ${contentType}`);
+          throw new Error(
+            `Unsupported content type: ${contentType} for document at index ${index}`,
+          );
       }
     }
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -361,7 +361,7 @@ export class Content {
       `/content/${this._id}/version/${version}`,
     );
 
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to revert content: ${res.statusText}`);
     }
 
@@ -376,7 +376,7 @@ export class Content {
       status,
     });
 
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to set content status: ${res.statusText}`);
     }
 
@@ -389,7 +389,7 @@ export class Content {
   async publish() {
     const res = await this.apiClient.POST(`/content/${this._id}/publish`);
 
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to publish content: ${res.statusText}`);
     }
 
@@ -402,7 +402,7 @@ export class Content {
   async unpublish() {
     const res = await this.apiClient.POST(`/content/${this._id}/unpublish`);
 
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to unpublish content: ${res.statusText}`);
     }
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -111,7 +111,7 @@ export class Cortex {
   ) {}
 
   static async get(apiClient: CortexApiClient, name: string): Promise<Cortex> {
-    const res = await apiClient.GET(`/cortex-config/${name}`);
+    const res = await apiClient.GET(`/cortexes/${name}`);
     if (res.status !== 200) {
       throw new Error(`Failed to get cortex: ${res.statusText}`);
     }
@@ -162,12 +162,12 @@ export class Cortex {
       personality: config.customizations?.personality,
       rules: config.customizations?.rules,
     };
-    const getRes = await apiClient.GET(`/cortex-config/${name}`);
+    const getRes = await apiClient.GET(`/cortexes/${name}`);
     let res: Response;
     if (getRes.status !== 200) {
-      res = await apiClient.POST("/cortex-config", input);
+      res = await apiClient.POST("/cortexes", input);
     } else {
-      res = await apiClient.PUT(`/cortex-config/${name}`, input);
+      res = await apiClient.PUT(`/cortexes/${name}`, input);
     }
 
     if (res.status !== 200) {
@@ -179,7 +179,7 @@ export class Cortex {
   async delete() {
     this.checkDeleted();
     this.deleted = true;
-    await this.apiClient.DELETE(`/cortex-config/${this.name}`);
+    await this.apiClient.DELETE(`/cortexes/${this.name}`);
     return;
   }
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -170,7 +170,7 @@ export class Cortex {
       res = await apiClient.PUT(`/cortexes/${name}`, input);
     }
 
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to configure cortex: ${res.statusText}`);
     }
     return new Cortex(config, apiClient, name);

--- a/src/document.ts
+++ b/src/document.ts
@@ -103,7 +103,7 @@ export class Document {
     const res = await this.apiClient.DELETE(
       `/catalogs/${this.catalog.name}/documents/${encodeURIComponent(this.documentId)}`,
     );
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to delete document: ${res.statusText}`);
     }
   }

--- a/src/org.ts
+++ b/src/org.ts
@@ -58,7 +58,7 @@ export class OrgConfig {
       res = await client.PUT("/org-config", config);
     }
 
-    if (res.status !== 200) {
+    if (res.status > 201) {
       throw new Error(`Failed to configure org: ${res.statusText}`);
     }
 


### PR DESCRIPTION
SDK cleanup: 
- [x] Expose warnings in upsertDocuments API result. Fixes #37 
- [x] Switch to `cortexes` API path. Fixes #38 
- [x] Review response status checking and prep for 201 status codes for create resource paths. Fixes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced document upsertion functionality that now provides user feedback through warnings during processing.
	- The `upsertDocuments` method now returns a structured result, improving clarity on operation outcomes.

- **Bug Fixes**
	- Broadened success criteria for API responses, allowing for more flexible handling of success statuses.
	- Improved error handling in document deletion to capture a wider range of failure responses.

- **Refactor**
	- Improved readability of the `upsertDocuments` method's internal logic.
	- Updated API endpoint paths for cortex configurations to align with new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->