### PR TITLE
Fix a bug re: Path.join

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/cortexclick/cortex-sdk",
     "type": "git"
   },
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -39,7 +39,13 @@ export class CortexApiClient {
       throw new Error("Request body too large");
     }
 
-    const url = Path.join(this.apiUrl, this.apiVersion, "org", this.org, path);
+    const url = Path.posix.join(
+      this.apiUrl,
+      this.apiVersion,
+      "org",
+      this.org,
+      path,
+    );
     return fetch(url, {
       method: "POST",
       headers: {


### PR DESCRIPTION
Fix a bug where I forgot to use `Path.posix.join` instead of `Path.join` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the package version to 0.0.12, signaling a new release.

- **Improvements**
  - Enhanced cross-platform compatibility for URL construction in the API client, ensuring consistent URL formatting across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->