### PR TITLE
Fix `Indexer.run` API to correctly process HTTP status code

### DIFF
--- a/src/indexers/hosted/hosted-indexers.test.ts
+++ b/src/indexers/hosted/hosted-indexers.test.ts
@@ -21,13 +21,13 @@ beforeEach(async () => {
 
   const catalogName = `catalog-${Date.now()}`;
   catalog = await testClient.configureCatalog(catalogName, config);
-}, 20000);
+}, 30000);
 
 afterEach(async () => {
   if (catalog) {
     await catalog.delete(); // this will also delete any indexer referencing this catalog
   }
-}, 20000);
+}, 30000);
 
 test("Test hosted indexer APIs", { timeout: 60000 }, async () => {
   const indexerName = `indexer-sdk-test-web-${Date.now()}`;

--- a/src/indexers/hosted/indexer.ts
+++ b/src/indexers/hosted/indexer.ts
@@ -131,7 +131,8 @@ export class Indexer {
 
   async run(): Promise<void> {
     const res = await this.apiClient.POST(`/indexers/${this.config.name}/run`);
-    if (res.status !== 200) {
+    // 200 is returned if the indexer was already running, 202 is returned if the indexer was started
+    if (res.status !== 202 && res.status !== 200) {
       const message = res.status === 400 ? await res.text() : res.statusText;
       throw new Error(`Failed to run indexer: ${message}`);
     }


### PR DESCRIPTION
Fix `Indexer.run` API to correctly handle response HTTP status code. 
Test missed it originally because the response is timing related - if the original indexer run (started when the indexer was created) is still in progress when `run` is called, 200 is returned; otherwise, 202 is returned. 